### PR TITLE
Add local date and time to logs and refactor text summary to button

### DIFF
--- a/src/game.ts
+++ b/src/game.ts
@@ -54,7 +54,7 @@ export class CogSpeedGame {
     public config: { [key: string]: any },
     private app: Application | null = null,
     private ui: CogSpeedGraphicsHandler | null = null,
-    private sleepData: { [key: string]: any } = {},
+    private sleepData: { [key: string]: any } = {}
   ) {}
 
   /**
@@ -157,7 +157,7 @@ export class CogSpeedGame {
     // 3) More than (roughly 12) correct answers that are less than (roughly 3000ms)
     // But not (roughly 4) correct answers in a row
     const correctAnswers = selfPacedAnswers.filter(
-      (answer) => answer.status === "correct" && answer.timeTaken <= this.config.self_paced.max_correct_duration,
+      (answer) => answer.status === "correct" && answer.timeTaken <= this.config.self_paced.max_correct_duration
     );
     if (correctAnswers.length >= this.config.self_paced.total_correct_count) return this.stop(2);
 
@@ -170,7 +170,7 @@ export class CogSpeedGame {
       this.currentTimeout =
         Math.min(
           lastNAnswers.map((answer) => answer.timeTaken).reduce((a, b) => a + b, 0) / 4,
-          this.config.machine_paced.max_start_duration,
+          this.config.machine_paced.max_start_duration
         ) - this.config.machine_paced.initial_speedup_amount; // Minimim response time (roughly 100ms)
       // Call next round
       return this.machinePacedRound();
@@ -474,7 +474,7 @@ export class CogSpeedGame {
     const highestBlockTime = Math.max(...this.previousBlockTimeouts.slice(1, blockCount + 1));
 
     const firstMachinePacedRound: { [key: string]: any } | undefined = this.previousAnswers.filter(
-      (answer: { [key: string]: any }) => answer.roundType === 2,
+      (answer: { [key: string]: any }) => answer.roundType === 2
     )[0];
 
     const totalMachinePacedAnswers = filterByRoundType(this.previousAnswers, 2);

--- a/src/startPage.ts
+++ b/src/startPage.ts
@@ -7,11 +7,7 @@ type GraphicList = [Graphics, number, number, number, number];
 export class StartPage {
   private container: Container;
 
-  constructor(
-    private config: { [key: string]: any },
-    private app: Application,
-    private ui: CogSpeedGraphicsHandler,
-  ) {
+  constructor(private config: { [key: string]: any }, private app: Application, private ui: CogSpeedGraphicsHandler) {
     this.container = new Container();
     this.app.stage.addChild(this.container);
   }
@@ -102,7 +98,7 @@ export class StartPage {
    */
   private async waitForKeyPress(
     sprite: (Sprite | Container | Text)[] = [this.container],
-    secondSprites: (Sprite | Container | Text)[] = [],
+    secondSprites: (Sprite | Container | Text)[] = []
   ): Promise<Sprite | Container | null> {
     [...sprite, ...secondSprites].forEach((sprite_) => {
       sprite_.eventMode = "dynamic";
@@ -159,7 +155,13 @@ export class StartPage {
     startTestText.position.set(this.app.screen.width * 0.5, this.app.screen.height * 0.8);
     this.container.addChild(startTestText);
 
-    this.createText(`Current test version is ${this.config.version}`, this.app.screen.width * 0.5, this.app.screen.height * 0.93, 14, {wordWrap: true});
+    this.createText(
+      `Current test version is ${this.config.version}`,
+      this.app.screen.width * 0.5,
+      this.app.screen.height * 0.93,
+      14,
+      { wordWrap: true }
+    );
 
     await this.waitForKeyPress([buttonBorder, startTestText]);
   }
@@ -177,7 +179,7 @@ export class StartPage {
       this.app.screen.width * 0.5,
       this.app.screen.height * 0.1,
       24,
-      { wordWrap: true },
+      { wordWrap: true }
     );
 
     this.createText("Ready?", this.app.screen.width * 0.5, this.app.screen.height * 0.5, 48, {
@@ -234,7 +236,7 @@ export class StartPage {
   private async displaySamnPerelliChecklist(): Promise<number> {
     var level = 0;
 
-    this.createText(`S-PF Checklist`, this.app.screen.width * 0.5, this.app.screen.height * 0.1, 24, { wordWrap: true })
+    this.createText(`S-PF Checklist`, this.app.screen.width * 0.5, this.app.screen.height * 0.1, 24, { wordWrap: true });
 
     const levels = [
       "Full alert, wide awake",
@@ -247,7 +249,7 @@ export class StartPage {
     ];
     const graphics: Array<GraphicList> = [];
     for (let index = levels.length - 1; index >= 0; index--) {
-      const y = this.app.screen.height * 0.15 + (index * this.app.screen.height * 0.09);
+      const y = this.app.screen.height * 0.15 + index * this.app.screen.height * 0.09;
       const x = this.app.screen.width * 0.1;
       const width = this.app.screen.width * 0.8;
       const height = this.app.screen.height * 0.09;
@@ -275,8 +277,14 @@ export class StartPage {
       this.container.addChild(text);
     }
 
-    this.createText(`Samn, S. & Perelli, L. (1981). Estimating Aircrew Fatigue: A Technique with Application to 
-    // Airlift Operations. SAM-TR-82-2.`, this.app.screen.width * 0.5, this.app.screen.height * 0.94, 12, { wordWrap: true });
+    this.createText(
+      `Samn, S. & Perelli, L. (1981). Estimating Aircrew Fatigue: A Technique with Application to 
+    // Airlift Operations. SAM-TR-82-2.`,
+      this.app.screen.width * 0.5,
+      this.app.screen.height * 0.94,
+      12,
+      { wordWrap: true }
+    );
 
     await this.waitForKeyPressNoDestroy(graphics.map((graphic) => graphic[0]));
     await this.confirm("Ok");
@@ -296,7 +304,13 @@ export class StartPage {
     readyDemo.position.set(this.app.screen.width * 0.5, this.app.screen.height * 0.45);
     readyDemo.anchor.set(0.5);
 
-    const container = this.ui.createButton("Start now", this.app.screen.width * 0.5, this.app.screen.height * 0.85, this.app.screen.width * 0.6, this.app.screen.height * 0.2)
+    const container = this.ui.createButton(
+      "Start now",
+      this.app.screen.width * 0.5,
+      this.app.screen.height * 0.85,
+      this.app.screen.width * 0.6,
+      this.app.screen.height * 0.2
+    );
 
     this.container.addChild(readyDemo);
     this.container.addChild(container);

--- a/src/ui/handler.ts
+++ b/src/ui/handler.ts
@@ -115,14 +115,15 @@ export class CogSpeedGraphicsHandler {
   }
 
   public createButton(content: string, x: number, y: number, width: number, height: number): Container {
-    const container = new Container()
+    const container = new Container();
+    container.eventMode = "dynamic";
 
     const button = new Sprite(this.largeButtonTexture);
     button.anchor.set(0.5);
     button.position.set(x, y);
     button.width = width;
     button.height = height;
-    
+
     const text = new Text(content, {
       fontFamily: "Trebuchet",
       fontSize: 24,
@@ -131,7 +132,7 @@ export class CogSpeedGraphicsHandler {
     });
     text.anchor.set(0.5);
     text.position.set(x, y);
-    
+
     container.addChild(button);
     container.addChild(text);
     return container;
@@ -243,7 +244,7 @@ export class CogSpeedGraphicsHandler {
       answerSprite,
       buttonPositions[answerLocation](this.gearWellSize, this.gearWellSize)[0],
       buttonPositions[answerLocation](this.gearWellSize, this.gearWellSize)[1],
-      answerLocation > 3 ? this.leftGearContainer : this.rightGearContainer,
+      answerLocation > 3 ? this.leftGearContainer : this.rightGearContainer
     );
 
     const numbers = Array.from({ length: 19 }, (x, i) => i);
@@ -264,7 +265,7 @@ export class CogSpeedGraphicsHandler {
         randomIncorrectSprite,
         buttonPositions[i + 1](this.gearWellSize, this.gearWellSize)[0],
         buttonPositions[i + 1](this.gearWellSize, this.gearWellSize)[1],
-        i > 2 ? this.leftGearContainer : this.rightGearContainer,
+        i > 2 ? this.leftGearContainer : this.rightGearContainer
       );
     }
   }

--- a/tests/game.test.ts
+++ b/tests/game.test.ts
@@ -165,14 +165,14 @@ describe("Test game algorithm", () => {
     game.buttonClicked(game.answer, 500); // Right answer (500ms)
     timeout += Math.max(
       (config.machine_paced.correct.x * (500 / timeout) - config.machine_paced.correct.y) * timeout,
-      -config.machine_paced.correct.max_speedup_amount,
+      -config.machine_paced.correct.max_speedup_amount
     );
     expect(game.currentTimeout).toBe(timeout);
 
     game.buttonClicked(game.answer, 1000); // Right answer (500ms + 500ms)
     timeout += Math.max(
       (config.machine_paced.correct.x * (500 / timeout) - config.machine_paced.correct.y) * timeout,
-      -config.machine_paced.correct.max_speedup_amount,
+      -config.machine_paced.correct.max_speedup_amount
     );
     expect(game.currentTimeout).toBe(timeout);
   });


### PR DESCRIPTION
This PR:
1. Refactors the results page (instead of a text summary, there is a view test logs button) [see below]
2. Adds local date and time to test logs
![image](https://github.com/Graymattermetrics/cogspeed/assets/23421705/2e99b486-d71f-4a53-ba4c-addcfe44e02b)


This pr also runs `npm run format` to format all the files